### PR TITLE
fix logic get downloadedpaper

### DIFF
--- a/public_api/serializers.py
+++ b/public_api/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from .models import (
     Conference,
     Dataset,
+    DownloadedPaper,
     InterestingDataset,
     Journal,
     Paper,
@@ -194,6 +195,68 @@ class PaperListSerializer(serializers.ModelSerializer):
             return []
 
 
+class LibraryItemSerializer(serializers.Serializer):
+    id = serializers.UUIDField(source="paper.id", read_only=True)
+    title = serializers.CharField(source="paper.title", read_only=True)
+    authors = serializers.SerializerMethodField()
+    conference = serializers.SerializerMethodField()
+    year = serializers.SerializerMethodField()
+    keywords = serializers.SerializerMethodField()
+    abstract = serializers.CharField(source="paper.abstract", read_only=True)
+    downloadUrl = serializers.SerializerMethodField()
+    is_interesting = serializers.SerializerMethodField()
+    is_downloaded = serializers.SerializerMethodField()
+    is_uploaded = serializers.SerializerMethodField()
+    added_date = serializers.DateTimeField(source="created_at", read_only=True)
+    doi = serializers.CharField(source="paper.doi", read_only=True)
+    bibtex = serializers.CharField(source="paper.bibtex", read_only=True)
+
+    class Meta:
+        fields = [
+            "id",
+            "title",
+            "authors",
+            "conference",
+            "year",
+            "keywords",
+            "abstract",
+            "downloadUrl",
+            "is_interesting",
+            "is_downloaded",
+            "is_uploaded",
+            "added_date",
+            "doi",
+            "bibtex",
+        ]
+
+    def get_authors(self, obj):
+        authors_list = [author.name for author in obj.paper.authors.all()]
+        return authors_list if authors_list else ["Unknown"]
+
+    def get_conference(self, obj):
+        if obj.paper.conference is not None:
+            return obj.paper.conference.name
+        return ""
+
+    def get_year(self, obj):
+        return obj.paper.publication_date.year if obj.paper.publication_date else None
+
+    def get_keywords(self, obj):
+        return obj.paper.keywords or []
+
+    def get_downloadUrl(self, obj):
+        return obj.paper.pdf_url
+
+    def get_is_interesting(self, obj):
+        return obj.paper.interested_users.filter(user=obj.user).exists()
+
+    def get_is_downloaded(self, obj):
+        return hasattr(obj, "paper") and obj.paper.downloaded_users.filter(user=obj.user).exists()
+
+    def get_is_uploaded(self, obj):
+        return bool(obj.paper.pdf_file)
+
+
 class DatasetListSerializer(serializers.ModelSerializer):
     downloadUrl = serializers.SerializerMethodField()
     category = serializers.SerializerMethodField()
@@ -276,6 +339,9 @@ class PaperDetailSerializer(PaperListSerializer):
     citationsByYear = serializers.SerializerMethodField()
     conferenceRank = serializers.SerializerMethodField()
     conferenceAbbreviation = serializers.SerializerMethodField()
+    is_interesting = serializers.SerializerMethodField()
+    is_downloaded = serializers.SerializerMethodField()
+    is_uploaded = serializers.SerializerMethodField()
 
     class Meta:
         model = Paper
@@ -301,6 +367,9 @@ class PaperDetailSerializer(PaperListSerializer):
             "conferenceRank",
             "conferenceAbbreviation",
             "datasets",
+            "is_interesting",
+            "is_downloaded",
+            "is_uploaded",
         ]
 
     def get_citationsByYear(self, obj):
@@ -343,6 +412,27 @@ class PaperDetailSerializer(PaperListSerializer):
             return obj.github_url
         else:
             return None
+
+    def _get_request_user(self):
+        request = self.context.get("request")
+        if request and request.user.is_authenticated:
+            return request.user
+        return None
+
+    def get_is_interesting(self, obj):
+        user = self._get_request_user()
+        if not user:
+            return False
+        return obj.interested_users.filter(user=user).exists()
+
+    def get_is_downloaded(self, obj):
+        user = self._get_request_user()
+        if not user:
+            return False
+        return obj.downloaded_users.filter(user=user).exists()
+
+    def get_is_uploaded(self, obj):
+        return bool(obj.pdf_file)
 
 
 class TaskSerializer(serializers.ModelSerializer):

--- a/public_api/views/general.py
+++ b/public_api/views/general.py
@@ -34,7 +34,9 @@ from ..models import (
 )
 from ..serializers import (
     DatasetSerializer,
+    LibraryItemSerializer,
     PaperSerializer,
+    PaperListSerializer,
     ProfileSerializer,
     PublicationSerializer,
 )
@@ -1088,17 +1090,23 @@ class MyLibrary(APIView):
         user = request.user
 
         if section == "interesting":
-            interesting = InterestingPaper.objects.filter(user=user)
-            paper_ids = [item.paper.id for item in interesting]
-            papers = Paper.objects.filter(id__in=paper_ids)
-            serializer = PaperSerializer(papers, many=True)
+            interesting = (
+                InterestingPaper.objects.filter(user=user)
+                .select_related("paper", "paper__journal", "paper__conference")
+                .prefetch_related("paper__authors")
+                .order_by("-created_at")
+            )
+            serializer = LibraryItemSerializer(interesting, many=True)
             return Response(serializer.data)
 
         elif section == "downloaded":
-            downloaded = DownloadedPaper.objects.filter(user=user)
-            paper_ids = [item.paper.id for item in downloaded]
-            papers = Paper.objects.filter(id__in=paper_ids)
-            serializer = PaperSerializer(papers, many=True)
+            downloaded = (
+                DownloadedPaper.objects.filter(user=user)
+                .select_related("paper", "paper__journal", "paper__conference")
+                .prefetch_related("paper__authors")
+                .order_by("-created_at")
+            )
+            serializer = LibraryItemSerializer(downloaded, many=True)
             return Response(serializer.data)
 
         elif section == "datasets":

--- a/public_api/views/paper.py
+++ b/public_api/views/paper.py
@@ -11,7 +11,11 @@ from rest_framework.views import APIView
 
 from ..error_responses import standard_error_response
 from ..models import Paper, InterestingPaper, DownloadedPaper
-from ..serializers import PaperDetailSerializer, PaperListSerializer, PaperSerializer
+from ..serializers import (
+    LibraryItemSerializer,
+    PaperDetailSerializer,
+    PaperListSerializer,
+)
 
 
 class PaperDetailView(APIView):
@@ -19,7 +23,7 @@ class PaperDetailView(APIView):
 
     def get(self, request, paper_id):
         paper = get_object_or_404(Paper, id=paper_id)
-        serializer = PaperDetailSerializer(paper)
+        serializer = PaperDetailSerializer(paper, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
@@ -34,7 +38,7 @@ class PaperBySlugView(APIView):
             queryset = queryset.filter(title__icontains=word)
         paper = queryset.first()
 
-        serializer = PaperDetailSerializer(paper)
+        serializer = PaperDetailSerializer(paper, context={"request": request})
         response_data = serializer.data
         return Response(response_data)
 
@@ -129,10 +133,13 @@ class ListDownloadedPapers(APIView):
 
     def get(self, request):
         user = request.user
-        downloaded_papers = DownloadedPaper.objects.filter(user=user).values_list(
-            "paper", flat=True
+        downloaded_papers = (
+            DownloadedPaper.objects.filter(user=user)
+            .select_related("paper", "paper__journal", "paper__conference")
+            .prefetch_related("paper__authors")
+            .order_by("-created_at")
         )
-        serializer = PaperSerializer(downloaded_papers, many=True)
+        serializer = LibraryItemSerializer(downloaded_papers, many=True)
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
## What changed

- Chuẩn hóa luồng DownloadPaper/Library để paper upload xong được trả về đúng trong danh sách downloaded/library.
- Tạo serializer dùng chung LibraryItemSerializer cho cả [InterestingPaper] và [DownloadedPaper]
- Đồng bộ response của library/upload theo cùng format, gồm các cờ [is_interesting], [is_downloaded], [is_uploaded]
- Sửa paper detail để trả thêm các cờ trạng thái theo user hiện tại, giúp FE render đúng trạng thái button và library.
## Why

- Trước đây paper upload thành công nhưng khi filter downloadedpaper/library FE không luôn nhận đúng item hoặc đúng format để hiển thị.
- Nguyên nhân chính là BE trả dữ liệu từ relation [DownloadedPaper] chưa đồng bộ với response shape mà FE đang dùng.

## Impact

- Paper upload xong sẽ xuất hiện đúng trong downloadedpaper/library theo flow hiện tại.
- FE có thể render đúng trạng thái bài báo đã upload/đã download/đã interesting mà không cần fallback.
